### PR TITLE
Typo: aproche -> approche

### DIFF
--- a/src/volume-3/arducomtoise.rst
+++ b/src/volume-3/arducomtoise.rst
@@ -427,7 +427,7 @@ cas de coupure de courant par exemple.
 J'ai donc intercalé un module `LipoRider
 <faitmain.org/volume-2/batterie.html>`_ qui permet à une batterie de 2000 mAh
 de prendre momentanément le relais en cas de défaillance de l'alimentation
-principale. Avec le capteur sur aiguille de la deuxième aproche cette
+principale. Avec le capteur sur aiguille de la deuxième approche cette
 précaution se justifie moins, mais je l'ai tout de même laissée.
 
 Evolution


### PR DESCRIPTION
Correction orthographique pour l'article arducomtoise.rst.
